### PR TITLE
Bug fix: fetch remote when creating a worktree off of an existing branch

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -18,6 +18,7 @@ type Git interface {
 	RemoveWorktree(string) (string, error)
 	AddWorktree(string, bool, string, string) error
 	GetRepoName(path string) (string, error)
+	FetchOrigin(branch string) error
 }
 
 type RealGit struct {
@@ -105,4 +106,12 @@ func (g *RealGit) GetRepoName(path string) (string, error) {
 	}
 	repoName := strings.TrimSuffix(filepath.Base(out), filepath.Ext(out))
 	return repoName, nil
+}
+
+func (g *RealGit) FetchOrigin(branch string) error {
+	_, err := g.shell.Cmd("git", "fetch", "origin", branch)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/git/mock_git.go
+++ b/git/mock_git.go
@@ -55,6 +55,24 @@ func (_m *MockGit) Clone(name string) (string, error) {
 	return r0, r1
 }
 
+// FetchOrigin provides a mock function with given fields: branch
+func (_m *MockGit) FetchOrigin(branch string) error {
+	ret := _m.Called(branch)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchOrigin")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(branch)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetLocalBranches provides a mock function with given fields:
 func (_m *MockGit) GetLocalBranches() ([]string, error) {
 	ret := _m.Called()


### PR DESCRIPTION
closes #12 

Fix for `add` worktree with an existing remote branch.