### PR TITLE
feat: add clone command

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -1,0 +1,73 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/garrettkrohn/treekanga/git"
+	spinner "github.com/garrettkrohn/treekanga/spinnerHuh"
+	util "github.com/garrettkrohn/treekanga/utility"
+	"github.com/spf13/cobra"
+)
+
+var (
+	url        string
+	folderName string
+)
+
+// initCmd represents the init command
+var cloneCmd = &cobra.Command{
+	Use:   "clone",
+	Short: "clone a bare repo",
+	Long:  `clone a bare repo with treekanga clone https://github.com/test/test`,
+	Run: func(cmd *cobra.Command, args []string) {
+		CloneBareRepo(deps.Git, spinner.NewRealHuhSpinner(), args)
+	},
+}
+
+func CloneBareRepo(git git.Git, spinner spinner.HuhSpinner, args []string) {
+	if len(args) == 0 {
+		fmt.Print("must include url to clone, folder name can be included optionally")
+	}
+
+	url = args[0]
+
+	if len(args) == 2 {
+		folderName = args[1]
+	} else {
+		folderName = getProjectName(url)
+		folderName = fmt.Sprintf("%s_bare", folderName)
+	}
+
+	spinner.Title("Cloning bare repo")
+	spinner.Action(func() {
+		err := deps.Git.CloneBare(url, folderName)
+		util.CheckError(err)
+	})
+	spinner.Run()
+}
+
+func getProjectName(url string) string {
+	lastSlashIndex := strings.LastIndex(url, "/")
+	if lastSlashIndex == -1 {
+		return url
+	}
+	return url[lastSlashIndex+1:]
+
+}
+
+func init() {
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// initCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// initCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,7 @@ func Execute(version string) {
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(cleanCmd)
 	rootCmd.AddCommand(deleteCmd)
+	rootCmd.AddCommand(cloneCmd)
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/git/git.go
+++ b/git/git.go
@@ -19,6 +19,7 @@ type Git interface {
 	AddWorktree(string, bool, string, string) error
 	GetRepoName(path string) (string, error)
 	FetchOrigin(branch string) error
+	CloneBare(string, string) error
 }
 
 type RealGit struct {
@@ -114,4 +115,13 @@ func (g *RealGit) FetchOrigin(branch string) error {
 		return err
 	}
 	return nil
+}
+
+func (g *RealGit) CloneBare(url string, folderName string) error {
+	_, err := g.shell.Cmd("git", "clone", "--bare", url, folderName)
+	if err != nil {
+		return err
+	}
+	return nil
+
 }


### PR DESCRIPTION
Add a clone command to clone a bare repo.  Includes the option to provide a folder name otherwise it will default to the following:
github.com/garrettkrohn/treekanga => treekanga_bare