### PR TITLE
add pull flag to the add command

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -39,6 +39,7 @@ var addCmd = &cobra.Command{
     You may also pass in the new branch and the base branch as
     arguments.`,
 	Run: func(cmd *cobra.Command, args []string) {
+
 		if len(args) >= 1 {
 			branchName = args[0]
 		}
@@ -89,6 +90,11 @@ var addCmd = &cobra.Command{
 
 			if baseBranch == "" {
 				baseBranch = viper.GetString("repos." + repoName + ".defaultBranch")
+			}
+
+			pull, err := cmd.Flags().GetBool("pull")
+			if pull {
+				deps.Git.PullBranch(baseBranch)
 			}
 
 			deps.Git.AddWorktree(folderName, existsRemotely, branchName, baseBranch)
@@ -179,5 +185,5 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	addCmd.Flags().BoolP("pull", "p", false, "Pull the base branch before creating new branch")
 }

--- a/git/git.go
+++ b/git/git.go
@@ -20,6 +20,7 @@ type Git interface {
 	GetRepoName(path string) (string, error)
 	FetchOrigin(branch string) error
 	CloneBare(string, string) error
+	PullBranch(url string) error
 }
 
 type RealGit struct {
@@ -123,5 +124,12 @@ func (g *RealGit) CloneBare(url string, folderName string) error {
 		return err
 	}
 	return nil
+}
 
+func (g *RealGit) PullBranch(url string) error {
+	_, err := g.shell.Cmd("git", "pull", url)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/git/mock_git.go
+++ b/git/mock_git.go
@@ -244,6 +244,24 @@ func (_m *MockGit) GitCommonDir(name string) (bool, string, error) {
 	return r0, r1, r2
 }
 
+// PullBranch provides a mock function with given fields: url
+func (_m *MockGit) PullBranch(url string) error {
+	ret := _m.Called(url)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PullBranch")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(url)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RemoveWorktree provides a mock function with given fields: _a0
 func (_m *MockGit) RemoveWorktree(_a0 string) (string, error) {
 	ret := _m.Called(_a0)


### PR DESCRIPTION
Adds the option for a -p or --pull flag to the add command.  This flag will pull the base branch before creating a new branch.  