### PR TITLE
add a sesh connect flag

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -128,16 +128,22 @@ var addCmd = &cobra.Command{
 
 		foldersToAddFromConfig := viper.GetStringSlice("repos." + repoName + ".zoxideFolders")
 		directoryReader := deps.DirectoryReader
-		foldersToAdd := getListOfZoxideEntries(branchName, repoName, parentDir, foldersToAddFromConfig, directoryReader)
+		foldersToAdd := getListOfZoxideEntries(branchName, parentDir, foldersToAddFromConfig, directoryReader)
 
 		addZoxideEntries(foldersToAdd)
+
+		connect, err := cmd.Flags().GetBool("connect")
+		if connect {
+			log.Info(fmt.Sprintf("Sesh connect to %s", foldersToAdd[0]))
+			deps.Sesh.SeshConnect(foldersToAdd[0])
+		}
 
 		//TODO: optional kill local session, and open it with the new branch
 
 	},
 }
 
-func getListOfZoxideEntries(branchName string, repoName string, parentDir string, foldersToAddFromConfig []string, directoryReader directoryReader.DirectoryReader) []string {
+func getListOfZoxideEntries(branchName string, parentDir string, foldersToAddFromConfig []string, directoryReader directoryReader.DirectoryReader) []string {
 	baseName := parentDir + "/" + branchName
 
 	var foldersToAdd []string
@@ -204,4 +210,5 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	addCmd.Flags().BoolP("pull", "p", false, "Pull the base branch before creating new branch")
+	addCmd.Flags().BoolP("connect", "c", false, "Automatically connect to a sesh upon creation")
 }

--- a/cmd/addZoxide_test.go
+++ b/cmd/addZoxide_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestZoxideAddEntriesNoConfig(t *testing.T) {
 	mockDirectoryReader := directoryReader.NewMockDirectoryReader(t)
-	actualOutput := getListOfZoxideEntries("baseBranch", "repoName", "parentDir", nil, mockDirectoryReader)
+	actualOutput := getListOfZoxideEntries("baseBranch", "parentDir", nil, mockDirectoryReader)
 
 	expectedOutput := []string{"parentDir/baseBranch"}
 
@@ -18,7 +18,7 @@ func TestZoxideAddEntriesNoConfig(t *testing.T) {
 
 func TestZoxideAddEntriesWithConfigNoWildcard(t *testing.T) {
 	mockDirectoryReader := directoryReader.NewMockDirectoryReader(t)
-	actualOutput := getListOfZoxideEntries("baseBranch", "repoName", "parentDir", []string{"test"}, mockDirectoryReader)
+	actualOutput := getListOfZoxideEntries("baseBranch", "parentDir", []string{"test"}, mockDirectoryReader)
 
 	expectedOutput := []string{"parentDir/baseBranch", "parentDir/baseBranch/test"}
 
@@ -31,7 +31,7 @@ func TestZoxideAddEntriesWithConfigWithWildcard(t *testing.T) {
 		"folder1",
 		"folder2",
 	}, nil)
-	actualOutput := getListOfZoxideEntries("baseBranch", "repoName", "parentDir", []string{"test", "test/*"}, mockDirectoryReader)
+	actualOutput := getListOfZoxideEntries("baseBranch", "parentDir", []string{"test", "test/*"}, mockDirectoryReader)
 
 	expectedOutput := []string{
 		"parentDir/baseBranch",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/garrettkrohn/treekanga/execwrap"
 	"github.com/garrettkrohn/treekanga/git"
 	"github.com/garrettkrohn/treekanga/logger"
+	"github.com/garrettkrohn/treekanga/sesh"
 	"github.com/garrettkrohn/treekanga/shell"
 	"github.com/garrettkrohn/treekanga/zoxide"
 	"github.com/spf13/cobra"
@@ -16,6 +17,7 @@ type Dependencies struct {
 	Git             git.Git
 	Zoxide          zoxide.Zoxide
 	DirectoryReader directoryReader.DirectoryReader
+	Sesh            sesh.Sesh
 }
 
 var (
@@ -23,7 +25,11 @@ var (
 	logLevel string // Variable to store the log level
 )
 
-func NewRootCmd(git git.Git, zoxide zoxide.Zoxide, directoryReader directoryReader.DirectoryReader, version string) *cobra.Command {
+func NewRootCmd(git git.Git,
+	zoxide zoxide.Zoxide,
+	directoryReader directoryReader.DirectoryReader,
+	sesh sesh.Sesh,
+	version string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     "treekanga",
 		Short:   "CLI application to manage git worktree",
@@ -34,6 +40,7 @@ func NewRootCmd(git git.Git, zoxide zoxide.Zoxide, directoryReader directoryRead
 				Git:             git,
 				Zoxide:          zoxide,
 				DirectoryReader: directoryReader,
+				Sesh:            sesh,
 			}
 			// Set the ENV environment variable based on the log level flag
 			// if logLevel != "" {
@@ -61,9 +68,10 @@ func Execute(version string) {
 	shell := shell.NewShell(execWrap)
 	git := git.NewGit(shell)
 	zoxide := zoxide.NewZoxide(shell)
+	sesh := sesh.NewSesh(shell)
 	directoryReader := directoryReader.NewDirectoryReader()
 
-	rootCmd := NewRootCmd(git, zoxide, directoryReader, version)
+	rootCmd := NewRootCmd(git, zoxide, directoryReader, sesh, version)
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(cleanCmd)

--- a/sesh/sesh.go
+++ b/sesh/sesh.go
@@ -1,0 +1,22 @@
+package sesh
+
+import (
+	"github.com/garrettkrohn/treekanga/shell"
+)
+
+type Sesh interface {
+	SeshConnect(seshName string) error
+}
+
+type RealSesh struct {
+	shell shell.Shell
+}
+
+func NewSesh(shell shell.Shell) Sesh {
+	return &RealSesh{shell}
+}
+
+func (r *RealSesh) SeshConnect(seshName string) error {
+	_, err := r.shell.Cmd("sesh", "connect", seshName)
+	return err
+}


### PR DESCRIPTION
Add the ability for a user to automatically connect to a sesh instance after creating a worktree.  Right now this just defaults to the main name, not any of the extra zoxide additions.

Resolves #28 