### PR TITLE
enable connect flag with specific sub folder

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -26,6 +26,8 @@ var (
 	baseBranch string
 )
 
+const tempZoxideName = "temp_treekanga_worktree"
+
 // addCmd represents the add command
 var addCmd = &cobra.Command{
 	Use:   "add",
@@ -112,14 +114,14 @@ var addCmd = &cobra.Command{
 			log.Info("pulling base branch before creating worktree", "base branch", baseBranch)
 			deps.Git.FetchOrigin(baseBranch)
 			deps.Git.CreateTempBranch()
-			baseBranch = "temp"
+			baseBranch = tempZoxideName
 		}
 
 		err = deps.Git.AddWorktree(folderName, existsLocally, branchName, baseBranch)
 		util.CheckError(err)
 
 		if pull {
-			deps.Git.DeleteBranch("temp")
+			deps.Git.DeleteBranch(tempZoxideName)
 		}
 		// }
 

--- a/git/git.go
+++ b/git/git.go
@@ -93,11 +93,11 @@ func (g *RealGit) RemoveWorktree(worktreeName string) (string, error) {
 	return out, nil
 }
 
-func (g *RealGit) AddWorktree(folderName string, existsOnRemote bool, branchName string, baseBranch string) error {
+func (g *RealGit) AddWorktree(folderName string, existsLocally bool, branchName string, baseBranch string) error {
 	var err error
 	var output string
 
-	if existsOnRemote {
+	if existsLocally {
 		log.Debug("branch exists on remote")
 		output, err = g.shell.Cmd("git", "worktree", "add", folderName, branchName)
 	} else {

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -1,14 +1,12 @@
 package utility
 
 import (
-	"log"
-	"os"
+	"github.com/charmbracelet/log"
 )
 
 // CheckError logs the error and terminates the program if the error is not nil.
 func CheckError(err error) {
 	if err != nil {
-		log.Printf("Error: %v", err)
-		os.Exit(1)
+		log.Fatal("Error: %v", err)
 	}
 }


### PR DESCRIPTION
- Allows the user to connect to the root zoxide path with the -c flag, or specify a sub folder with a string `-c frontend`
- changed the temporary worktree name to a more br specific and less likely to be used

Completes #39 