### PR TITLE
add a directory flag to add command to run from anywhere

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -45,7 +45,14 @@ var addCmd = &cobra.Command{
 		}
 
 		path, err := cmd.Flags().GetString("directory")
-		log.Debug(path)
+		if cmd.Flags().Changed("directory") {
+			log.Debug(fmt.Sprintf("inputted path: %s ", path))
+		}
+
+		_, err = os.Stat(path)
+		if err != nil {
+			log.Fatal("path does not exist")
+		}
 
 		baseBranch, err := cmd.Flags().GetString("base")
 		util.CheckError(err)

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -84,7 +84,7 @@ func getWorktrees(git git.Git, transformer *transformer.RealTransformer) []workt
 }
 
 func getRemoteBranches(git git.Git, transformer *transformer.RealTransformer) []string {
-	branches, error := git.GetRemoteBranches()
+	branches, error := git.GetRemoteBranches("")
 	if error != nil {
 		log.Fatal(error)
 	}

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -21,7 +21,7 @@ func TestDeleteWorktreesWithClean(t *testing.T) {
 		"/Users/gkrohn/code/development       abcdef12345 [branch1]",
 		"/Users/gkrohn/code/featureBranch     abcdef12345 [branch2]",
 	}, nil)
-	mockGit.On("GetRemoteBranches").Return([]string{
+	mockGit.On("GetRemoteBranches", mock.Anything).Return([]string{
 		"/Users/gkrohn/code/development       abcdef12345 [branch1]",
 	}, nil)
 	mockGit.On("RemoveWorktree", "development").Return("", nil)

--- a/git/git.go
+++ b/git/git.go
@@ -118,17 +118,6 @@ func (g *RealGit) AddWorktree(folderName string, existsLocally bool,
 
 	output, err := g.shell.Cmd("git", gitCommand...)
 
-	// var err error
-	// var output string
-	//
-	// if existsLocally {
-	// 	log.Debug("branch exists on remote")
-	// 	output, err = g.shell.Cmd("git", "worktree", "add", folderName, branchName)
-	// } else {
-	// 	log.Debug("branch does not exist on remote")
-	// 	output, err = g.shell.Cmd("git", "worktree", "add", folderName, "-b", branchName, baseBranch)
-	// }
-
 	if err != nil {
 		return fmt.Errorf("failed to add worktree: %v, %s", err, output)
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -9,21 +9,24 @@ import (
 	"github.com/garrettkrohn/treekanga/shell"
 )
 
+const tempZoxideName = "temp_treekanga_worktree"
+
+// TODO: make a a function to add the directory
 type Git interface {
 	ShowTopLevel(name string) (bool, string, error)
 	GitCommonDir(name string) (bool, string, error)
 	Clone(name string) (string, error)
-	GetRemoteBranches() ([]string, error)
-	GetLocalBranches() ([]string, error)
+	GetRemoteBranches(string) ([]string, error)
+	GetLocalBranches(string) ([]string, error)
 	GetWorktrees() ([]string, error)
 	RemoveWorktree(string) (string, error)
-	AddWorktree(string, bool, string, string) error
+	AddWorktree(string, bool, string, string, string) error
 	GetRepoName(path string) (string, error)
-	FetchOrigin(branch string) error
+	FetchOrigin(branch string, path string) error
 	CloneBare(string, string) error
 	PullBranch(url string) error
-	CreateTempBranch() error
-	DeleteBranch(branch string) error
+	CreateTempBranch(path string) error
+	DeleteBranch(branch string, path string) error
 }
 
 type RealGit struct {
@@ -58,19 +61,28 @@ func (g *RealGit) Clone(name string) (string, error) {
 	return out, nil
 }
 
-func (g *RealGit) GetRemoteBranches() ([]string, error) {
+func (g *RealGit) GetRemoteBranches(path string) ([]string, error) {
 	// prune
-	g.shell.Cmd("git", "fetch", "--prune")
+	fetchCmd := getBaseCommandWithOrWithoutPath(path)
+	fetchCmd = append(fetchCmd, "fetch", "--prune")
+	g.shell.Cmd("git", fetchCmd...)
 
 	// fetch
-	g.shell.Cmd("git", "fetch", "origin")
+	fetchCmd2 := getBaseCommandWithOrWithoutPath(path)
+	fetchCmd2 = append(fetchCmd2, "fetch", "origin")
+	g.shell.Cmd("git", fetchCmd2...)
 
 	//get all branches
-	return g.shell.ListCmd("git", "branch", "-r", "--format=\"%(refname:short)\"")
+	branchCmd := getBaseCommandWithOrWithoutPath(path)
+	branchCmd = append(branchCmd, "branch", "-r", "--format=\"%(refname:short)\"")
+	list, err := g.shell.ListCmd("git", branchCmd...)
+	return list, err
 }
 
-func (g *RealGit) GetLocalBranches() ([]string, error) {
-	branches, err := g.shell.ListCmd("git", "branch", "--format='%(refname:short)'")
+func (g *RealGit) GetLocalBranches(path string) ([]string, error) {
+	gitCmd := getBaseCommandWithOrWithoutPath(path)
+	gitCmd = append(gitCmd, "branch", "--format='%(refname:short)'")
+	branches, err := g.shell.ListCmd("git", gitCmd...)
 	if err != nil {
 		return nil, err
 	}
@@ -93,17 +105,29 @@ func (g *RealGit) RemoveWorktree(worktreeName string) (string, error) {
 	return out, nil
 }
 
-func (g *RealGit) AddWorktree(folderName string, existsLocally bool, branchName string, baseBranch string) error {
-	var err error
-	var output string
+func (g *RealGit) AddWorktree(folderName string, existsLocally bool,
+	branchName string, baseBranch string, path string) error {
+	gitCommand := getBaseCommandWithOrWithoutPath(path)
+	gitCommand = append(gitCommand, "worktree", "add", folderName)
 
 	if existsLocally {
-		log.Debug("branch exists on remote")
-		output, err = g.shell.Cmd("git", "worktree", "add", folderName, branchName)
+		gitCommand = append(gitCommand, branchName)
 	} else {
-		log.Debug("branch does not exist on remote")
-		output, err = g.shell.Cmd("git", "worktree", "add", folderName, "-b", branchName, baseBranch)
+		gitCommand = append(gitCommand, "-b", branchName, baseBranch)
 	}
+
+	output, err := g.shell.Cmd("git", gitCommand...)
+
+	// var err error
+	// var output string
+	//
+	// if existsLocally {
+	// 	log.Debug("branch exists on remote")
+	// 	output, err = g.shell.Cmd("git", "worktree", "add", folderName, branchName)
+	// } else {
+	// 	log.Debug("branch does not exist on remote")
+	// 	output, err = g.shell.Cmd("git", "worktree", "add", folderName, "-b", branchName, baseBranch)
+	// }
 
 	if err != nil {
 		return fmt.Errorf("failed to add worktree: %v, %s", err, output)
@@ -112,6 +136,7 @@ func (g *RealGit) AddWorktree(folderName string, existsLocally bool, branchName 
 	return nil
 }
 
+// Note: path is figured out in add.go
 func (g *RealGit) GetRepoName(path string) (string, error) {
 	out, err := g.shell.Cmd("git", "-C", path, "config", "--get", "remote.origin.url")
 	if err != nil {
@@ -121,8 +146,10 @@ func (g *RealGit) GetRepoName(path string) (string, error) {
 	return repoName, nil
 }
 
-func (g *RealGit) FetchOrigin(branch string) error {
-	_, err := g.shell.Cmd("git", "fetch", "origin", branch)
+func (g *RealGit) FetchOrigin(branch string, path string) error {
+	gitCmd := getBaseCommandWithOrWithoutPath(path)
+	gitCmd = append(gitCmd, "fetch", "origin", branch)
+	_, err := g.shell.Cmd("git", gitCmd...)
 	if err != nil {
 		return err
 	}
@@ -146,18 +173,32 @@ func (g *RealGit) PullBranch(url string) error {
 	return nil
 }
 
-func (g *RealGit) CreateTempBranch() error {
-	_, err := g.shell.Cmd("git", "branch", "temp", "FETCH_HEAD")
+func (g *RealGit) CreateTempBranch(path string) error {
+	gitCmd := getBaseCommandWithOrWithoutPath(path)
+	gitCmd = append(gitCmd, "branch", tempZoxideName, "FETCH_HEAD")
+	_, err := g.shell.Cmd("git", gitCmd...)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (g *RealGit) DeleteBranch(branch string) error {
-	_, err := g.shell.Cmd("git", "checkout", "-d", branch)
+func (g *RealGit) DeleteBranch(branch string, path string) error {
+	gitCmd := getBaseCommandWithOrWithoutPath(path)
+	gitCmd = append(gitCmd, "checkout", "-d", branch)
+	_, err := g.shell.Cmd("git", gitCmd...)
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func getBaseCommandWithOrWithoutPath(path string) []string {
+	gitCommand := make([]string, 0)
+
+	if path != "" {
+		gitCommand = append(gitCommand, "-C", path)
+	}
+
+	return gitCommand
 }

--- a/git/mock_git.go
+++ b/git/mock_git.go
@@ -17,17 +17,17 @@ func (_m *MockGit) EXPECT() *MockGit_Expecter {
 	return &MockGit_Expecter{mock: &_m.Mock}
 }
 
-// AddWorktree provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *MockGit) AddWorktree(_a0 string, _a1 bool, _a2 string, _a3 string) error {
-	ret := _m.Called(_a0, _a1, _a2, _a3)
+// AddWorktree provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4
+func (_m *MockGit) AddWorktree(_a0 string, _a1 bool, _a2 string, _a3 string, _a4 string) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddWorktree")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, bool, string, string) error); ok {
-		r0 = rf(_a0, _a1, _a2, _a3)
+	if rf, ok := ret.Get(0).(func(string, bool, string, string, string) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -45,13 +45,14 @@ type MockGit_AddWorktree_Call struct {
 //   - _a1 bool
 //   - _a2 string
 //   - _a3 string
-func (_e *MockGit_Expecter) AddWorktree(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}) *MockGit_AddWorktree_Call {
-	return &MockGit_AddWorktree_Call{Call: _e.mock.On("AddWorktree", _a0, _a1, _a2, _a3)}
+//   - _a4 string
+func (_e *MockGit_Expecter) AddWorktree(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}, _a4 interface{}) *MockGit_AddWorktree_Call {
+	return &MockGit_AddWorktree_Call{Call: _e.mock.On("AddWorktree", _a0, _a1, _a2, _a3, _a4)}
 }
 
-func (_c *MockGit_AddWorktree_Call) Run(run func(_a0 string, _a1 bool, _a2 string, _a3 string)) *MockGit_AddWorktree_Call {
+func (_c *MockGit_AddWorktree_Call) Run(run func(_a0 string, _a1 bool, _a2 string, _a3 string, _a4 string)) *MockGit_AddWorktree_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(bool), args[2].(string), args[3].(string))
+		run(args[0].(string), args[1].(bool), args[2].(string), args[3].(string), args[4].(string))
 	})
 	return _c
 }
@@ -61,7 +62,7 @@ func (_c *MockGit_AddWorktree_Call) Return(_a0 error) *MockGit_AddWorktree_Call 
 	return _c
 }
 
-func (_c *MockGit_AddWorktree_Call) RunAndReturn(run func(string, bool, string, string) error) *MockGit_AddWorktree_Call {
+func (_c *MockGit_AddWorktree_Call) RunAndReturn(run func(string, bool, string, string, string) error) *MockGit_AddWorktree_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -169,17 +170,17 @@ func (_c *MockGit_CloneBare_Call) RunAndReturn(run func(string, string) error) *
 	return _c
 }
 
-// CreateTempBranch provides a mock function with no fields
-func (_m *MockGit) CreateTempBranch() error {
-	ret := _m.Called()
+// CreateTempBranch provides a mock function with given fields: path
+func (_m *MockGit) CreateTempBranch(path string) error {
+	ret := _m.Called(path)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateTempBranch")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(path)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -193,13 +194,14 @@ type MockGit_CreateTempBranch_Call struct {
 }
 
 // CreateTempBranch is a helper method to define mock.On call
-func (_e *MockGit_Expecter) CreateTempBranch() *MockGit_CreateTempBranch_Call {
-	return &MockGit_CreateTempBranch_Call{Call: _e.mock.On("CreateTempBranch")}
+//   - path string
+func (_e *MockGit_Expecter) CreateTempBranch(path interface{}) *MockGit_CreateTempBranch_Call {
+	return &MockGit_CreateTempBranch_Call{Call: _e.mock.On("CreateTempBranch", path)}
 }
 
-func (_c *MockGit_CreateTempBranch_Call) Run(run func()) *MockGit_CreateTempBranch_Call {
+func (_c *MockGit_CreateTempBranch_Call) Run(run func(path string)) *MockGit_CreateTempBranch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -209,22 +211,22 @@ func (_c *MockGit_CreateTempBranch_Call) Return(_a0 error) *MockGit_CreateTempBr
 	return _c
 }
 
-func (_c *MockGit_CreateTempBranch_Call) RunAndReturn(run func() error) *MockGit_CreateTempBranch_Call {
+func (_c *MockGit_CreateTempBranch_Call) RunAndReturn(run func(string) error) *MockGit_CreateTempBranch_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeleteBranch provides a mock function with given fields: branch
-func (_m *MockGit) DeleteBranch(branch string) error {
-	ret := _m.Called(branch)
+// DeleteBranch provides a mock function with given fields: branch, path
+func (_m *MockGit) DeleteBranch(branch string, path string) error {
+	ret := _m.Called(branch, path)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteBranch")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(branch)
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(branch, path)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -239,13 +241,14 @@ type MockGit_DeleteBranch_Call struct {
 
 // DeleteBranch is a helper method to define mock.On call
 //   - branch string
-func (_e *MockGit_Expecter) DeleteBranch(branch interface{}) *MockGit_DeleteBranch_Call {
-	return &MockGit_DeleteBranch_Call{Call: _e.mock.On("DeleteBranch", branch)}
+//   - path string
+func (_e *MockGit_Expecter) DeleteBranch(branch interface{}, path interface{}) *MockGit_DeleteBranch_Call {
+	return &MockGit_DeleteBranch_Call{Call: _e.mock.On("DeleteBranch", branch, path)}
 }
 
-func (_c *MockGit_DeleteBranch_Call) Run(run func(branch string)) *MockGit_DeleteBranch_Call {
+func (_c *MockGit_DeleteBranch_Call) Run(run func(branch string, path string)) *MockGit_DeleteBranch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(string), args[1].(string))
 	})
 	return _c
 }
@@ -255,22 +258,22 @@ func (_c *MockGit_DeleteBranch_Call) Return(_a0 error) *MockGit_DeleteBranch_Cal
 	return _c
 }
 
-func (_c *MockGit_DeleteBranch_Call) RunAndReturn(run func(string) error) *MockGit_DeleteBranch_Call {
+func (_c *MockGit_DeleteBranch_Call) RunAndReturn(run func(string, string) error) *MockGit_DeleteBranch_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// FetchOrigin provides a mock function with given fields: branch
-func (_m *MockGit) FetchOrigin(branch string) error {
-	ret := _m.Called(branch)
+// FetchOrigin provides a mock function with given fields: branch, path
+func (_m *MockGit) FetchOrigin(branch string, path string) error {
+	ret := _m.Called(branch, path)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchOrigin")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(branch)
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(branch, path)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -285,13 +288,14 @@ type MockGit_FetchOrigin_Call struct {
 
 // FetchOrigin is a helper method to define mock.On call
 //   - branch string
-func (_e *MockGit_Expecter) FetchOrigin(branch interface{}) *MockGit_FetchOrigin_Call {
-	return &MockGit_FetchOrigin_Call{Call: _e.mock.On("FetchOrigin", branch)}
+//   - path string
+func (_e *MockGit_Expecter) FetchOrigin(branch interface{}, path interface{}) *MockGit_FetchOrigin_Call {
+	return &MockGit_FetchOrigin_Call{Call: _e.mock.On("FetchOrigin", branch, path)}
 }
 
-func (_c *MockGit_FetchOrigin_Call) Run(run func(branch string)) *MockGit_FetchOrigin_Call {
+func (_c *MockGit_FetchOrigin_Call) Run(run func(branch string, path string)) *MockGit_FetchOrigin_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(string), args[1].(string))
 	})
 	return _c
 }
@@ -301,14 +305,14 @@ func (_c *MockGit_FetchOrigin_Call) Return(_a0 error) *MockGit_FetchOrigin_Call 
 	return _c
 }
 
-func (_c *MockGit_FetchOrigin_Call) RunAndReturn(run func(string) error) *MockGit_FetchOrigin_Call {
+func (_c *MockGit_FetchOrigin_Call) RunAndReturn(run func(string, string) error) *MockGit_FetchOrigin_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetLocalBranches provides a mock function with no fields
-func (_m *MockGit) GetLocalBranches() ([]string, error) {
-	ret := _m.Called()
+// GetLocalBranches provides a mock function with given fields: _a0
+func (_m *MockGit) GetLocalBranches(_a0 string) ([]string, error) {
+	ret := _m.Called(_a0)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLocalBranches")
@@ -316,19 +320,19 @@ func (_m *MockGit) GetLocalBranches() ([]string, error) {
 
 	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]string, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(string) ([]string, error)); ok {
+		return rf(_a0)
 	}
-	if rf, ok := ret.Get(0).(func() []string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -342,13 +346,14 @@ type MockGit_GetLocalBranches_Call struct {
 }
 
 // GetLocalBranches is a helper method to define mock.On call
-func (_e *MockGit_Expecter) GetLocalBranches() *MockGit_GetLocalBranches_Call {
-	return &MockGit_GetLocalBranches_Call{Call: _e.mock.On("GetLocalBranches")}
+//   - _a0 string
+func (_e *MockGit_Expecter) GetLocalBranches(_a0 interface{}) *MockGit_GetLocalBranches_Call {
+	return &MockGit_GetLocalBranches_Call{Call: _e.mock.On("GetLocalBranches", _a0)}
 }
 
-func (_c *MockGit_GetLocalBranches_Call) Run(run func()) *MockGit_GetLocalBranches_Call {
+func (_c *MockGit_GetLocalBranches_Call) Run(run func(_a0 string)) *MockGit_GetLocalBranches_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -358,14 +363,14 @@ func (_c *MockGit_GetLocalBranches_Call) Return(_a0 []string, _a1 error) *MockGi
 	return _c
 }
 
-func (_c *MockGit_GetLocalBranches_Call) RunAndReturn(run func() ([]string, error)) *MockGit_GetLocalBranches_Call {
+func (_c *MockGit_GetLocalBranches_Call) RunAndReturn(run func(string) ([]string, error)) *MockGit_GetLocalBranches_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetRemoteBranches provides a mock function with no fields
-func (_m *MockGit) GetRemoteBranches() ([]string, error) {
-	ret := _m.Called()
+// GetRemoteBranches provides a mock function with given fields: _a0
+func (_m *MockGit) GetRemoteBranches(_a0 string) ([]string, error) {
+	ret := _m.Called(_a0)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRemoteBranches")
@@ -373,19 +378,19 @@ func (_m *MockGit) GetRemoteBranches() ([]string, error) {
 
 	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]string, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(string) ([]string, error)); ok {
+		return rf(_a0)
 	}
-	if rf, ok := ret.Get(0).(func() []string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -399,13 +404,14 @@ type MockGit_GetRemoteBranches_Call struct {
 }
 
 // GetRemoteBranches is a helper method to define mock.On call
-func (_e *MockGit_Expecter) GetRemoteBranches() *MockGit_GetRemoteBranches_Call {
-	return &MockGit_GetRemoteBranches_Call{Call: _e.mock.On("GetRemoteBranches")}
+//   - _a0 string
+func (_e *MockGit_Expecter) GetRemoteBranches(_a0 interface{}) *MockGit_GetRemoteBranches_Call {
+	return &MockGit_GetRemoteBranches_Call{Call: _e.mock.On("GetRemoteBranches", _a0)}
 }
 
-func (_c *MockGit_GetRemoteBranches_Call) Run(run func()) *MockGit_GetRemoteBranches_Call {
+func (_c *MockGit_GetRemoteBranches_Call) Run(run func(_a0 string)) *MockGit_GetRemoteBranches_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -415,7 +421,7 @@ func (_c *MockGit_GetRemoteBranches_Call) Return(_a0 []string, _a1 error) *MockG
 	return _c
 }
 
-func (_c *MockGit_GetRemoteBranches_Call) RunAndReturn(run func() ([]string, error)) *MockGit_GetRemoteBranches_Call {
+func (_c *MockGit_GetRemoteBranches_Call) RunAndReturn(run func(string) ([]string, error)) *MockGit_GetRemoteBranches_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
completes #37 

allows the user to set the bare repo directory with a -p flag for the add command