### PR TITLE
redo logic for add

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,19 @@ You can define the branch and base branch directly from the command line
 
 `treekanga add example_branch`
 
-If a base branch is not defined it will use the defaults base branch from the
-config file, if not present it will use the current branch
+logic for branche / worktrees:
+- if example_branch exists locally: create a worktree with that branch
+- if example_branch exists remotely: create a worktree with a new local version
+  of that branch
+
+`treekanga add example_branch -b base_branch`
+error will be thrown if base_branch doesn't exist locally or remotely
+- if the baseBranch exists locally: create a new example_branch off of the local
+  base_branch
+- if it exists locally and the pull flag (-p) is used: create a new 
+  example_branch off of the remote base_branch
+- if baseBranch doesn't exist locally: create new worktree with new
+example_branch off of remote base_branch
 
 `treekanga add`
 

--- a/git/mock_git.go
+++ b/git/mock_git.go
@@ -17,17 +17,17 @@ func (_m *MockGit) EXPECT() *MockGit_Expecter {
 	return &MockGit_Expecter{mock: &_m.Mock}
 }
 
-// AddWorktree provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5
-func (_m *MockGit) AddWorktree(_a0 string, _a1 bool, _a2 bool, _a3 string, _a4 string, _a5 string) error {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
+// AddWorktree provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8
+func (_m *MockGit) AddWorktree(_a0 string, _a1 bool, _a2 bool, _a3 string, _a4 string, _a5 string, _a6 bool, _a7 bool, _a8 bool) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddWorktree")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, bool, bool, string, string, string) error); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
+	if rf, ok := ret.Get(0).(func(string, bool, bool, string, string, string, bool, bool, bool) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -47,13 +47,16 @@ type MockGit_AddWorktree_Call struct {
 //   - _a3 string
 //   - _a4 string
 //   - _a5 string
-func (_e *MockGit_Expecter) AddWorktree(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}, _a4 interface{}, _a5 interface{}) *MockGit_AddWorktree_Call {
-	return &MockGit_AddWorktree_Call{Call: _e.mock.On("AddWorktree", _a0, _a1, _a2, _a3, _a4, _a5)}
+//   - _a6 bool
+//   - _a7 bool
+//   - _a8 bool
+func (_e *MockGit_Expecter) AddWorktree(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}, _a4 interface{}, _a5 interface{}, _a6 interface{}, _a7 interface{}, _a8 interface{}) *MockGit_AddWorktree_Call {
+	return &MockGit_AddWorktree_Call{Call: _e.mock.On("AddWorktree", _a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8)}
 }
 
-func (_c *MockGit_AddWorktree_Call) Run(run func(_a0 string, _a1 bool, _a2 bool, _a3 string, _a4 string, _a5 string)) *MockGit_AddWorktree_Call {
+func (_c *MockGit_AddWorktree_Call) Run(run func(_a0 string, _a1 bool, _a2 bool, _a3 string, _a4 string, _a5 string, _a6 bool, _a7 bool, _a8 bool)) *MockGit_AddWorktree_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(bool), args[2].(bool), args[3].(string), args[4].(string), args[5].(string))
+		run(args[0].(string), args[1].(bool), args[2].(bool), args[3].(string), args[4].(string), args[5].(string), args[6].(bool), args[7].(bool), args[8].(bool))
 	})
 	return _c
 }
@@ -63,7 +66,7 @@ func (_c *MockGit_AddWorktree_Call) Return(_a0 error) *MockGit_AddWorktree_Call 
 	return _c
 }
 
-func (_c *MockGit_AddWorktree_Call) RunAndReturn(run func(string, bool, bool, string, string, string) error) *MockGit_AddWorktree_Call {
+func (_c *MockGit_AddWorktree_Call) RunAndReturn(run func(string, bool, bool, string, string, string, bool, bool, bool) error) *MockGit_AddWorktree_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
I redid the logic for the add worktree command to allow for more control over what branch is created and or used.