### PR TITLE
Allow completion commands to be run outside of configured worktree

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,10 @@ func NewRootCmd(git git.Git,
 				BareRepoPath:    "",
 			}
 
+			if cmd.Name() == "completion" || cmd.HasParent() && cmd.Parent().Name() == "completion" {
+				return
+			}
+
 			repoName, bareRepoPath := resolveRepoNameAndPath()
 			deps.ResolvedRepo = repoName
 			deps.BareRepoPath = bareRepoPath


### PR DESCRIPTION
When running `treekanga completion bash` outside of a configured worktree, the CLI fails because it's attempting to ensure the command is ran from within a configured worktree.

This fixes it to skip that check on all completion commands and sub commands.