### PR TITLE
add ability to select the base branch

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -27,6 +27,7 @@ var addCmd = &cobra.Command{
 
     Available flags:
     -b, --base: Specify the base branch for the new worktree
+    -f, --from: Select base branch from list of existing worktrees (sorted by recent use)
     -p, --pull: Pull the base branch before creating new branch
     -c, --cursor: Open the new worktree in Cursor
     -v, --vscode: Open the new worktree in VS Code
@@ -74,6 +75,7 @@ func init() {
 	addCmd.Flags().BoolP("cursor", "c", false, "Open up new worktree in cursor")
 	addCmd.Flags().BoolP("vscode", "v", false, "Open up new worktree in vs code")
 	addCmd.Flags().BoolP("script", "x", false, "Execute Custom Script")
+	addCmd.Flags().BoolP("from", "f", false, "Select base branch from list of branches")
 	addCmd.Flags().StringP("sesh", "s", "", "Automatically connect to a sesh upon creation")
 	addCmd.Flags().StringP("base", "b", "", "Specify the base branch for the new worktree")
 	addCmd.Flags().StringP("directory", "d", "", "Specify the directory to the bare repo where the worktree will be added")

--- a/common/types.go
+++ b/common/types.go
@@ -100,6 +100,7 @@ type AddCmdFlags struct {
 	VsCode                *bool
 	SpecifiedWorktreeName *string
 	ExecuteScript         *bool
+	From                  *bool
 }
 
 type GitInfo struct {

--- a/zoxide/mock_zoxide.go
+++ b/zoxide/mock_zoxide.go
@@ -99,6 +99,62 @@ func (_c *MockZoxide_AddZoxideEntries_Call) RunAndReturn(run func(*common.AddCon
 	return _c
 }
 
+// QueryScore provides a mock function with given fields: path
+func (_m *MockZoxide) QueryScore(path string) (float64, error) {
+	ret := _m.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryScore")
+	}
+
+	var r0 float64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (float64, error)); ok {
+		return rf(path)
+	}
+	if rf, ok := ret.Get(0).(func(string) float64); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockZoxide_QueryScore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryScore'
+type MockZoxide_QueryScore_Call struct {
+	*mock.Call
+}
+
+// QueryScore is a helper method to define mock.On call
+//   - path string
+func (_e *MockZoxide_Expecter) QueryScore(path interface{}) *MockZoxide_QueryScore_Call {
+	return &MockZoxide_QueryScore_Call{Call: _e.mock.On("QueryScore", path)}
+}
+
+func (_c *MockZoxide_QueryScore_Call) Run(run func(path string)) *MockZoxide_QueryScore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockZoxide_QueryScore_Call) Return(_a0 float64, _a1 error) *MockZoxide_QueryScore_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockZoxide_QueryScore_Call) RunAndReturn(run func(string) (float64, error)) *MockZoxide_QueryScore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemovePath provides a mock function with given fields: path
 func (_m *MockZoxide) RemovePath(path string) error {
 	ret := _m.Called(path)


### PR DESCRIPTION
adds the `-f` flag to the add command that allows the user to set the basebranch from their current worktrees.  This allows the user to easily stack their branches for PRs.