### PR TITLE
output git clone progress to the treekanga clone command

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -49,19 +49,18 @@ func CloneBareRepo(git git.Git, spinner spinner.HuhSpinner, args []string) {
 		folderName = fmt.Sprintf("%s_bare", folderName)
 	}
 
-	spinner.Title("Cloning bare repo")
-	spinner.Action(func() {
-		err := git.CloneBare(url, folderName)
-		util.CheckError(err)
+	// Clone with streaming output so user can see git progress
+	err := git.CloneBare(url, folderName)
+	util.CheckError(err)
 
-		workingDir, err := os.Getwd()
-		util.CheckError(err)
+	workingDir, err := os.Getwd()
+	util.CheckError(err)
 
-		barePath := workingDir + "/" + folderName
+	barePath := workingDir + "/" + folderName
 
-		git.ConfigureGitBare(barePath)
-	})
-	spinner.Run()
+	git.ConfigureGitBare(barePath)
+	
+	fmt.Printf("\n✓ Successfully cloned %s\n", folderName)
 }
 
 func getProjectName(url string) string {

--- a/git/git.go
+++ b/git/git.go
@@ -82,14 +82,14 @@ func (g *RealGit) RemoveWorktree(worktreeName string, path *string) (string, err
 		if err != nil {
 			log.Debug("Could not fix .git file", "error", err)
 		}
-		
+
 		relPath, err := filepath.Rel(*path, worktreeName)
 		if err == nil {
 			worktreePath = relPath
 			log.Debug("Using relative path for worktree removal", "absolute", worktreeName, "relative", relPath)
 		}
 	}
-	
+
 	gitCmd := getBaseArguementsWithOrWithoutPath(path)
 	gitCmd = append(gitCmd, "worktree", "remove", worktreePath, "--force")
 	log.Debug("git args", "args", gitCmd)
@@ -105,7 +105,7 @@ func (g *RealGit) fixWorktreeGitFile(worktreePath string, bareRepoPath string) e
 	gitFilePath := filepath.Join(worktreePath, ".git")
 	worktreeName := filepath.Base(worktreePath)
 	expectedGitDir := filepath.Join(bareRepoPath, "worktrees", worktreeName)
-	
+
 	// Write the corrected .git file using Go's file I/O
 	content := fmt.Sprintf("gitdir: %s\n", expectedGitDir)
 	err := os.WriteFile(gitFilePath, []byte(content), 0644)
@@ -170,7 +170,7 @@ func (g *RealGit) GetRepoName(path string) (string, error) {
 }
 
 func (g *RealGit) CloneBare(url string, folderName string) error {
-	_, err := g.shell.Cmd("git", "clone", "--bare", url, folderName)
+	err := g.shell.CmdWithStreaming("git", "clone", "--progress", "--bare", url, folderName)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func (g *RealGit) ConfigureGitBare(path string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	// After configuring the fetch refspec, we need to fetch to populate remote-tracking branches
 	// In a bare clone, branches are initially in refs/heads/, but we want them in refs/remotes/origin/
 	_, err = g.shell.Cmd("git", "-C", path, "fetch", "origin")
@@ -212,7 +212,7 @@ func (g *RealGit) ConfigureGitBare(path string) error {
 		log.Debug("Warning: fetch after bare config failed", "error", err)
 		// Don't return error as the repo might still be usable
 	}
-	
+
 	return nil
 }
 

--- a/shell/mock_Shell.go
+++ b/shell/mock_Shell.go
@@ -233,6 +233,67 @@ func (_c *MockShell_ListCmd_Call) RunAndReturn(run func(string, ...string) ([]st
 	return _c
 }
 
+// CmdWithStreaming provides a mock function with given fields: cmd, args
+func (_m *MockShell) CmdWithStreaming(cmd string, args ...string) error {
+	_va := make([]interface{}, len(args))
+	for _i := range args {
+		_va[_i] = args[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, cmd)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CmdWithStreaming")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, ...string) error); ok {
+		r0 = rf(cmd, args...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockShell_CmdWithStreaming_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CmdWithStreaming'
+type MockShell_CmdWithStreaming_Call struct {
+	*mock.Call
+}
+
+// CmdWithStreaming is a helper method to define mock.On call
+//   - cmd string
+//   - args ...string
+func (_e *MockShell_Expecter) CmdWithStreaming(cmd interface{}, args ...interface{}) *MockShell_CmdWithStreaming_Call {
+	return &MockShell_CmdWithStreaming_Call{Call: _e.mock.On("CmdWithStreaming",
+		append([]interface{}{cmd}, args...)...)}
+}
+
+func (_c *MockShell_CmdWithStreaming_Call) Run(run func(cmd string, args ...string)) *MockShell_CmdWithStreaming_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]string, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(string)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockShell_CmdWithStreaming_Call) Return(_a0 error) *MockShell_CmdWithStreaming_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShell_CmdWithStreaming_Call) RunAndReturn(run func(string, ...string) error) *MockShell_CmdWithStreaming_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockShell creates a new instance of MockShell. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockShell(t interface {


### PR DESCRIPTION
Closes request #95 to output the progress of the `git clone` command when `treekanga clone` is executed. Implemented a shell function that streams the stdout and used that for the clone command.