### PR TITLE
change post script directory to new root, instead of bare

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ Clone a repository as a bare worktree:
 treekanga clone https://www.github.com/example/example
 ```
 
+### TUI (In Beta)
+
+```bash
+treekanga tui
+```
+
 ## Logging
 
 Control log verbosity:

--- a/services/addService.go
+++ b/services/addService.go
@@ -130,7 +130,7 @@ func AddWorktree(gitClient adapters.GitAdapter, zoxide adapters.Zoxide, connecto
 		selectedBranch := handleFromForm(*form, branchStrings)
 		cfg.BaseBranch = selectedBranch
 		log.Debug(fmt.Sprintf("Set BaseBranch = %s from form selection", selectedBranch))
-		
+
 		// Update the BaseBranchExistsLocally flag after selection
 		t := transformer.NewTransformer()
 		localBranches, err := gitClient.GetLocalBranches(&cfg.BareRepoPath)
@@ -189,7 +189,7 @@ func AddWorktree(gitClient adapters.GitAdapter, zoxide adapters.Zoxide, connecto
 	if cfg.RunPostScript {
 		log.Info("Runnning post script")
 		script := cfg.PostScriptPath
-		shell.CmdWithDir(cfg.WorktreeTargetDir, "sh", "-c", script)
+		shell.CmdWithDir(newRootDirectory, "sh", "-c", script)
 		log.Info("post script run", "command", script)
 	}
 }


### PR DESCRIPTION
Bug fix: post script being run from the .bare repo instead of the new worktree.