### PR TITLE
feat(connect): add post-script execution support

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -55,13 +55,23 @@ Examples:
 			return
 		}
 
+		executeScript, err := cmd.Flags().GetBool("script")
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+		if executeScript {
+			log.Debug("set RunPostScript = true from flags")
+			deps.AppConfig.RunPostScript = true
+		}
+
 		opts := models.ConnectOpts{
 			Switch: switchFlag,
 		}
 
 		log.Debug("Attempting to connect", "name", name, "switch", switchFlag)
 
-		if err := deps.Connector.Connect(name, opts); err != nil {
+		if err := deps.Connector.ConnectWithConfig(name, opts, deps.AppConfig.PostScriptPath, deps.AppConfig.RunPostScript); err != nil {
 			log.Fatal(err)
 			return
 		}
@@ -72,4 +82,5 @@ Examples:
 
 func init() {
 	connectCmd.Flags().BoolP("switch", "s", false, "Switch to the session (rather than attach). Useful when already inside tmux.")
+	connectCmd.Flags().BoolP("script", "x", false, "Execute Custom Script")
 }

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/charmbracelet/log"
 	"github.com/garrettkrohn/treekanga/adapters"
 	"github.com/garrettkrohn/treekanga/git"
 	"github.com/garrettkrohn/treekanga/models"
@@ -17,6 +18,7 @@ import (
 
 type Connector interface {
 	Connect(name string, opts models.ConnectOpts) error
+	ConnectWithConfig(name string, opts models.ConnectOpts, postScriptPath string, runPostScript bool) error
 	VsCodeConnect(newRootPath string)
 	CursorConnect(newRootPath string)
 }
@@ -35,23 +37,34 @@ func NewConnector(shell shell.Shell) Connector {
 
 // Connect attempts to connect to a session using various strategies
 func (r *RealConnector) Connect(name string, opts models.ConnectOpts) error {
+	return r.ConnectWithConfig(name, opts, "", false)
+}
+
+// ConnectWithConfig attempts to connect to a session and optionally runs a post-script
+func (r *RealConnector) ConnectWithConfig(name string, opts models.ConnectOpts, postScriptPath string, runPostScript bool) error {
 	strategies := []func(string) (models.Connection, error){
 		r.tmuxStrategy,
 		r.worktreeStrategy,
 		r.dirStrategy,
 	}
 
+	var connection models.Connection
 	for _, strategy := range strategies {
-		connection, err := strategy(name)
+		conn, err := strategy(name)
 		if err != nil {
 			return fmt.Errorf("connection strategy error: %w", err)
 		}
-		if connection.Found {
-			return r.connectToTmux(connection, opts)
+		if conn.Found {
+			connection = conn
+			break
 		}
 	}
 
-	return fmt.Errorf("no connection found for '%s'", name)
+	if !connection.Found {
+		return fmt.Errorf("no connection found for '%s'", name)
+	}
+
+	return r.connectToTmuxWithPostScript(connection, opts, postScriptPath, runPostScript)
 }
 
 // tmuxStrategy checks if a tmux session with the given name exists
@@ -182,6 +195,27 @@ func (r *RealConnector) connectToTmux(connection models.Connection, opts models.
 	return r.tmux.SwitchOrAttach(connection.Session.Name, opts)
 }
 
+// connectToTmuxWithPostScript handles the connection to tmux and optionally runs a post-script in the session
+func (r *RealConnector) connectToTmuxWithPostScript(connection models.Connection, opts models.ConnectOpts, postScriptPath string, runPostScript bool) error {
+	if connection.New {
+		// Create new session
+		if err := r.tmux.NewSession(connection.Session.Name, connection.Session.Path); err != nil {
+			return fmt.Errorf("failed to create tmux session: %w", err)
+		}
+
+		// Execute post-script in the tmux session if configured
+		if runPostScript && postScriptPath != "" {
+			if err := r.executePostScriptInTmux(connection.Session.Name, postScriptPath); err != nil {
+				// Log warning but don't fail the connection
+				log.Warn("Failed to execute post-script in tmux", "path", postScriptPath, "error", err)
+			}
+		}
+	}
+
+	// Switch or attach to the session
+	return r.tmux.SwitchOrAttach(connection.Session.Name, opts)
+}
+
 func (r *RealConnector) VsCodeConnect(newRootPath string) {
 	_, err := r.shell.Cmd("code", newRootPath)
 	utility.CheckError(err)
@@ -190,4 +224,47 @@ func (r *RealConnector) VsCodeConnect(newRootPath string) {
 func (r *RealConnector) CursorConnect(newRootPath string) {
 	_, err := r.shell.Cmd("cursor", newRootPath)
 	utility.CheckError(err)
+}
+
+// executePostScript runs the configured post-script in the given directory
+func (r *RealConnector) executePostScript(directory, scriptPath string) error {
+	// Expand tilde in script path
+	expandedPath := scriptPath
+	if strings.HasPrefix(scriptPath, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		expandedPath = filepath.Join(homeDir, scriptPath[2:])
+	}
+
+	log.Info("Running post script", "script", expandedPath, "directory", directory)
+	_, err := r.shell.CmdWithDir(directory, "sh", expandedPath)
+	if err != nil {
+		return fmt.Errorf("post script execution failed: %w", err)
+	}
+	log.Info("Post script completed successfully")
+	return nil
+}
+
+// executePostScriptInTmux runs the configured post-script inside a tmux session
+func (r *RealConnector) executePostScriptInTmux(sessionName, scriptPath string) error {
+	// Expand tilde in script path
+	expandedPath := scriptPath
+	if strings.HasPrefix(scriptPath, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		expandedPath = filepath.Join(homeDir, scriptPath[2:])
+	}
+
+	log.Info("Running post script in tmux session", "script", expandedPath, "session", sessionName)
+	// Send the command to the tmux session
+	_, err := r.shell.Cmd("tmux", "send-keys", "-t", sessionName, "sh "+expandedPath, "Enter")
+	if err != nil {
+		return fmt.Errorf("failed to send post script to tmux session: %w", err)
+	}
+	log.Info("Post script command sent to tmux session")
+	return nil
 }

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -1,7 +1,15 @@
 package connector
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/garrettkrohn/treekanga/execwrap"
+	"github.com/garrettkrohn/treekanga/models"
+	"github.com/garrettkrohn/treekanga/shell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateSessionName(t *testing.T) {
@@ -204,4 +212,94 @@ func TestGenerateWorktreeSessionNameRealWorldExamples(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecutePostScript(t *testing.T) {
+	// Skip if running in CI without shell
+	if os.Getenv("SKIP_INTEGRATION_TESTS") != "" {
+		t.Skip("Skipping integration test")
+	}
+
+	t.Run("executes post script successfully", func(t *testing.T) {
+		// Create a temporary directory and script
+		tempDir, err := os.MkdirTemp("", "connector-postscript-test-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		// Create a simple test script that creates a marker file
+		markerFile := filepath.Join(tempDir, "script-executed.txt")
+		scriptPath := filepath.Join(tempDir, "test-script.sh")
+		scriptContent := "#!/bin/sh\necho 'Script executed' > " + markerFile
+		err = os.WriteFile(scriptPath, []byte(scriptContent), 0755)
+		require.NoError(t, err)
+
+		// Create connector with real shell
+		execWrap := execwrap.NewExec()
+		sh := shell.NewShell(execWrap)
+		connector := NewConnector(sh).(*RealConnector)
+
+		// Execute the post script
+		err = connector.executePostScript(tempDir, scriptPath)
+		assert.NoError(t, err, "Post script should execute successfully")
+
+		// Verify the marker file was created
+		_, err = os.Stat(markerFile)
+		assert.NoError(t, err, "Marker file should exist after script execution")
+	})
+
+	t.Run("handles script execution failure gracefully", func(t *testing.T) {
+		// Create a temporary directory
+		tempDir, err := os.MkdirTemp("", "connector-postscript-fail-test-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		// Create a script that exits with error
+		scriptPath := filepath.Join(tempDir, "failing-script.sh")
+		scriptContent := "#!/bin/sh\nexit 1"
+		err = os.WriteFile(scriptPath, []byte(scriptContent), 0755)
+		require.NoError(t, err)
+
+		// Create connector with real shell
+		execWrap := execwrap.NewExec()
+		sh := shell.NewShell(execWrap)
+		connector := NewConnector(sh).(*RealConnector)
+
+		// Execute the failing post script
+		err = connector.executePostScript(tempDir, scriptPath)
+		assert.Error(t, err, "Post script should return an error when it fails")
+	})
+}
+
+func TestConnectWithConfig_PostScript(t *testing.T) {
+	// Skip if running in CI
+	if os.Getenv("SKIP_INTEGRATION_TESTS") != "" {
+		t.Skip("Skipping integration test")
+	}
+
+	t.Run("does not execute post script when runPostScript is false", func(t *testing.T) {
+		// Create a temporary directory
+		tempDir, err := os.MkdirTemp("", "connector-config-test-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		// Create a marker file that should NOT be created
+		markerFile := filepath.Join(tempDir, "should-not-exist.txt")
+		scriptPath := filepath.Join(tempDir, "test-script.sh")
+		scriptContent := "#!/bin/sh\necho 'Should not run' > " + markerFile
+		err = os.WriteFile(scriptPath, []byte(scriptContent), 0755)
+		require.NoError(t, err)
+
+		// Create connector
+		execWrap := execwrap.NewExec()
+		sh := shell.NewShell(execWrap)
+		connector := NewConnector(sh).(*RealConnector)
+
+		// Try to connect to a non-existent session (will fail, but we just want to verify script isn't run)
+		opts := models.ConnectOpts{Switch: false}
+		_ = connector.ConnectWithConfig("non-existent-session", opts, scriptPath, false)
+
+		// Verify the marker file was NOT created
+		_, err = os.Stat(markerFile)
+		assert.True(t, os.IsNotExist(err), "Marker file should not exist when runPostScript is false")
+	})
 }

--- a/services/addService.go
+++ b/services/addService.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -224,9 +225,9 @@ func AddWorktree(connector connector.Connector, shell shell.Shell, cfg config.Ap
 			connectPath = newRootDirectory + "/" + cfg.TmuxConnect
 		}
 		opts := models.ConnectOpts{Switch: false}
-		if err := connector.Connect(connectPath, opts); err != nil {
+		if err := connector.ConnectWithConfig(connectPath, opts, cfg.PostScriptPath, cfg.RunPostScript); err != nil {
 			log.Warn("Subdirectory not found, connecting to root instead", "subdirectory", cfg.TmuxConnect)
-			if err := connector.Connect(newRootDirectory, opts); err != nil {
+			if err := connector.ConnectWithConfig(newRootDirectory, opts, cfg.PostScriptPath, cfg.RunPostScript); err != nil {
 				log.Error("Failed to connect to tmux session", "error", err)
 			}
 		}
@@ -240,11 +241,22 @@ func AddWorktree(connector connector.Connector, shell shell.Shell, cfg config.Ap
 		connector.VsCodeConnect(newRootDirectory)
 	}
 
-	//TODO: allow the user to set where this is run?
-	if cfg.RunPostScript {
-		log.Info("Runnning post script")
+	// Post-script execution is handled by ConnectWithConfig when using tmux connect flag
+	// If not connecting to a new session, run the script in the current context
+	if cfg.RunPostScript && cfg.TmuxConnect == "" && !cfg.CursorConnect && !cfg.VsCodeConnect {
+		log.Info("Running post script in current session")
 		script := cfg.PostScriptPath
-		shell.CmdWithDir(newRootDirectory, "sh", "-c", script)
-		log.Info("post script run", "command", script)
+		// Expand tilde in script path
+		expandedPath := script
+		if len(script) > 2 && script[0] == '~' && script[1] == '/' {
+			homeDir, err := os.UserHomeDir()
+			if err == nil {
+				expandedPath = homeDir + script[1:]
+			}
+		}
+		// Run the script in a subshell so the user stays in their current directory
+		command := fmt.Sprintf("(cd %s && sh %s)", newRootDirectory, expandedPath)
+		shell.Cmd("tmux", "send-keys", "-t", ".", command, "Enter")
+		log.Info("Post script command sent to current session")
 	}
 }


### PR DESCRIPTION
Add ability to execute custom post-scripts when connecting to tmux sessions:
- Add ConnectWithConfig method to Connector interface
- Add --script/-x flag to connect command
- Execute post-script in session directory before connecting
- Log warnings on script failure without blocking connection
- Add integration tests for post-script execution

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>

This is a feature that has existed, but it wouldn't run the script in the new tmux session, which is what I want to happen.