### PR TITLE
chore: replace makefile with justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+# Run tests with coverage
+test:
+    go test -cover -bench=. -benchmem -race ./... -coverprofile=coverage.out
+
+# Build treekanga binary to GOPATH/bin
+build:
+    go build -buildvcs=false -ldflags "-X 'main.version=`git describe --tags --abbrev=0`'" -o `go env GOPATH`/bin/treekanga

--- a/makefile
+++ b/makefile
@@ -1,9 +1,0 @@
-.PHONY: test build
-
-BUILD_FLAGS="-X 'main.version=`git describe --tags --abbrev=0`'"
-
-test:
-	go test -cover -bench=. -benchmem -race ./... -coverprofile=coverage.out
-
-build: 
-	@go build -ldflags ${BUILD_FLAGS} -o $(shell echo $$GOPATH)/bin/treekanga


### PR DESCRIPTION
## Summary
- Remove `makefile` and add an equivalent `justfile` with `test` and `build` recipes
- `build` recipe adds `-buildvcs=false` and uses `go env GOPATH` for the output path

## Why
- `just` has worked better than `make` for my workflow, aligning the build tooling with my sesh project and state setup

## Notes
- Recipes are functionally equivalent to the old makefile targets